### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -41,9 +41,9 @@
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/mobile.css" />
     <link rel="stylesheet" href="{{ .Site.BaseURL }}bower_components/cal-heatmap/cal-heatmap.css" />
 
-    {{ if .RSSlink }}
-    <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSlink }}"/>
-    <link rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSlink }}" />
+    {{ if .RSSLink }}
+    <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSLink }}"/>
+    <link rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSLink }}" />
     {{ end }}
 
     <!--

--- a/layouts/partials/navbar-icon.html
+++ b/layouts/partials/navbar-icon.html
@@ -16,7 +16,7 @@
 </li>
 
 <li>
-	<a href="{{ .RSSlink }}">
+	<a href="{{ .RSSLink }}">
 		 <i class="fa fa-rss-square" aria-hidden="true"></i>
 	</a>
 </li>


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.